### PR TITLE
fix: handle manifests broken by description-block YAML quirks and over-eager error guards

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -50,3 +50,7 @@ allow_defined_top = true
 -- Don't warn about unused arguments in hook functions
 -- These are part of the plugin API signature
 unused_args = false
+
+exclude_files = {
+    "lib/yaml.lua", -- vendored third-party (lua-tinyyaml)
+}

--- a/.styluaignore
+++ b/.styluaignore
@@ -1,0 +1,1 @@
+lib/yaml.lua

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -192,6 +192,10 @@ mise cache clear
 - 4 spaces, 120 column width
 - Run `stylua` before committing (or use `hk install` for auto-format)
 
+## Commit Messages
+
+Commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`).
+
 ## Releasing
 
 1. Ensure CI passes: `mise run test`

--- a/NOTICE
+++ b/NOTICE
@@ -3,16 +3,16 @@ Third-Party Licenses
 
 This project includes code from third-party libraries:
 
-lua-yaml
---------
-Copyright (c) 2017 Dominic Letz <dominicletz@exosite.com>
+lua-tinyyaml
+------------
+Copyright (c) 2017 peposso
 
-Source: https://github.com/exosite/lua-yaml
+Source: https://github.com/zepinglee/lua-tinyyaml
 License: MIT
 
 The MIT License (MIT)
 
-Copyright (c) 2017 Dominic Letz
+Copyright (c) 2017 peposso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/hk.pkl
+++ b/hk.pkl
@@ -8,8 +8,8 @@ local linters = new Mapping<String, Step> {
     }
     ["stylua"] {
         glob = "**/*.lua"
-        check = "stylua --check {{files}}"
-        fix = "stylua {{files}}"
+        check = "stylua --respect-ignores --check {{files}}"
+        fix = "stylua --respect-ignores {{files}}"
     }
     ["actionlint"] {
         glob = ".github/workflows/*.{yml,yaml}"

--- a/hooks/backend_install.lua
+++ b/hooks/backend_install.lua
@@ -61,7 +61,7 @@ function PLUGIN:BackendInstall(ctx)
 
     local file = require("file")
     local source = platform.bin and platform.bin:match("[^/]+$")
-    local target = source and installer.target_bin_name(tool, ctx.options)
+    local target = source and installer.target_bin_name(tool)
     if source and source ~= target then
         local from = file.join_path(install_path, source)
         if file.exists(from) then

--- a/lib/installer.lua
+++ b/lib/installer.lua
@@ -9,11 +9,7 @@ end
 
 -- kubectl invokes `foo-bar` plugins as `kubectl foo bar` unless the binary is
 -- named with underscores. Mirrors krew's pluginNameToBin.
-function M.target_bin_name(tool, opts)
-    local override = opts and opts.rename_exe
-    if override and override ~= "" then
-        return override
-    end
+function M.target_bin_name(tool)
     return "kubectl-" .. tool:gsub("-", "_")
 end
 

--- a/lib/manifest.lua
+++ b/lib/manifest.lua
@@ -9,7 +9,7 @@ local M = {}
 function M.parse(yaml_str)
     local yaml = require("yaml")
 
-    local ok, result = pcall(yaml.eval, yaml_str)
+    local ok, result = pcall(yaml.parse, yaml_str)
     if not ok then
         return nil, "Failed to parse manifest: " .. tostring(result)
     end

--- a/lib/registry.lua
+++ b/lib/registry.lua
@@ -104,8 +104,7 @@ function M.get_file_history(plugin_name)
     local registry_path = M.get_registry_path()
 
     local plugin_path = "plugins/" .. plugin_name .. ".yaml"
-    local log_cmd =
-        string.format("git --no-pager log --format=%%H --no-show-signature --follow -- %s 2>/dev/null", plugin_path)
+    local log_cmd = string.format("git --no-pager log --format=%%H --no-show-signature -- %s 2>/dev/null", plugin_path)
 
     local result = cmd.exec(log_cmd, { cwd = registry_path })
 
@@ -136,10 +135,9 @@ function M.get_manifest_at_commit(plugin_name, commit_hash)
     local plugin_path = "plugins/" .. plugin_name .. ".yaml"
     local show_cmd = string.format("git show %s:%s", commit_hash, plugin_path)
 
-    local result = cmd.exec(show_cmd, { cwd = registry_path })
-
-    if result:match("fatal") or result:match("error") then
-        return nil, "Failed to get manifest at commit " .. commit_hash
+    local ok, result = pcall(cmd.exec, show_cmd, { cwd = registry_path })
+    if not ok then
+        return nil, "Failed to get manifest at commit " .. commit_hash .. ": " .. tostring(result)
     end
 
     return result, nil

--- a/lib/yaml.lua
+++ b/lib/yaml.lua
@@ -1,568 +1,860 @@
--- lib/yaml.lua
--- Vendored lua-yaml from https://github.com/exosite/lua-yaml
--- MIT License - Copyright (c) 2016 Exosite
+-------------------------------------------------------------------------------
+-- tinyyaml - YAML subset parser
+-------------------------------------------------------------------------------
 
-local table_print_value
-table_print_value = function(value, indent, done)
-    indent = indent or 0
-    done = done or {}
-    if type(value) == "table" and not done[value] then
-        done[value] = true
+local table = table
+local string = string
+local schar = string.char
+local ssub, gsub = string.sub, string.gsub
+local sfind, smatch = string.find, string.match
+local tinsert, tconcat, tremove = table.insert, table.concat, table.remove
+local setmetatable = setmetatable
+local pairs = pairs
+local rawget = rawget
+local type = type
+local tonumber = tonumber
+local math = math
+local getmetatable = getmetatable
+local error = error
+local end_symbol = "..."
+local end_break_symbol = "...\n"
 
-        local list = {}
-        for key in pairs(value) do
-            list[#list + 1] = key
-        end
-        table.sort(list, function(a, b)
-            return tostring(a) < tostring(b)
-        end)
-        local last = list[#list]
+local UNESCAPES = {
+  ['0'] = "\x00", z = "\x00", N    = "\x85",
+  a = "\x07",     b = "\x08", t    = "\x09",
+  n = "\x0a",     v = "\x0b", f    = "\x0c",
+  r = "\x0d",     e = "\x1b", ['\\'] = '\\',
+};
 
-        local rep = "{\n"
-        local comma
-        for _, key in ipairs(list) do
-            if key == last then
-                comma = ""
-            else
-                comma = ","
-            end
-            local keyRep
-            if type(key) == "number" then
-                keyRep = key
-            else
-                keyRep = string.format("%q", tostring(key))
-            end
-            rep = rep
-                .. string.format(
-                    "%s[%s] = %s%s\n",
-                    string.rep(" ", indent + 2),
-                    keyRep,
-                    table_print_value(value[key], indent + 2, done),
-                    comma
-                )
-        end
-
-        rep = rep .. string.rep(" ", indent)
-        rep = rep .. "}"
-
-        done[value] = false
-        return rep
-    elseif type(value) == "string" then
-        return string.format("%q", value)
-    else
-        return tostring(value)
+-------------------------------------------------------------------------------
+-- utils
+local function select(list, pred)
+  local selected = {}
+  for i = 0, #list do
+    local v = list[i]
+    if v and pred(v, i) then
+      tinsert(selected, v)
     end
+  end
+  return selected
 end
 
-local table_print = function(tt)
-    print("return " .. table_print_value(tt))
+local function startswith(haystack, needle)
+  return ssub(haystack, 1, #needle) == needle
 end
 
-local table_clone = function(t)
-    local clone = {}
-    for k, v in pairs(t) do
-        clone[k] = v
-    end
-    return clone
+local function ltrim(str)
+  return smatch(str, "^%s*(.-)$")
 end
 
-local string_trim = function(s, what)
-    what = what or " "
-    return s:gsub("^[" .. what .. "]*(.-)[" .. what .. "]*$", "%1")
+local function rtrim(str)
+  return smatch(str, "^(.-)%s*$")
 end
 
-local push = function(stack, item)
-    stack[#stack + 1] = item
+local function trim(str)
+  return smatch(str, "^%s*(.-)%s*$")
 end
 
-local pop = function(stack)
-    local item = stack[#stack]
-    stack[#stack] = nil
-    return item
+-------------------------------------------------------------------------------
+-- Implementation.
+--
+local class = {__meta={}}
+function class.__meta.__call(cls, ...)
+  local self = setmetatable({}, cls)
+  if cls.__init then
+    cls.__init(self, ...)
+  end
+  return self
 end
 
-local context = function(str)
-    if type(str) ~= "string" then
-        return ""
-    end
-
-    str = str:sub(0, 25):gsub("\n", "\\n"):gsub('"', '\\"')
-    return ', near "' .. str .. '"'
+function class.def(base, typ, cls)
+  base = base or class
+  local mt = {__metatable=base, __index=base}
+  for k, v in pairs(base.__meta) do mt[k] = v end
+  cls = setmetatable(cls or {}, mt)
+  cls.__index = cls
+  cls.__metatable = cls
+  cls.__type = typ
+  cls.__meta = mt
+  return cls
 end
 
-local Parser = {}
-function Parser.new(self, tokens)
-    self.tokens = tokens
-    self.parse_stack = {}
-    self.refs = {}
-    self.current = 0
-    return self
-end
 
-local exports = { version = "1.2" }
-
-local word = function(w)
-    return "^(" .. w .. ")([%s$%c])"
-end
-
-local tokens = {
-    { "comment", "^#[^\n]*" },
-    { "indent", "^\n( *)" },
-    { "space", "^ +" },
-    { "true", word("enabled"), const = true, value = true },
-    { "true", word("true"), const = true, value = true },
-    { "true", word("yes"), const = true, value = true },
-    { "true", word("on"), const = true, value = true },
-    { "false", word("disabled"), const = true, value = false },
-    { "false", word("false"), const = true, value = false },
-    { "false", word("no"), const = true, value = false },
-    { "false", word("off"), const = true, value = false },
-    { "null", word("null"), const = true, value = nil },
-    { "null", word("Null"), const = true, value = nil },
-    { "null", word("NULL"), const = true, value = nil },
-    { "null", word("~"), const = true, value = nil },
-    { "id", '^"([^"]-)" *(:[%s%c])' },
-    { "id", "^'([^']-)' *(:[%s%c])" },
-    { "string", '^"([^"]-)"', force_text = true },
-    { "string", "^'([^']-)'", force_text = true },
-    { "timestamp", "^(%d%d%d%d)-(%d%d?)-(%d%d?)%s+(%d%d?):(%d%d):(%d%d)%s+(-?%d%d?):(%d%d)" },
-    { "timestamp", "^(%d%d%d%d)-(%d%d?)-(%d%d?)%s+(%d%d?):(%d%d):(%d%d)%s+(-?%d%d?)" },
-    { "timestamp", "^(%d%d%d%d)-(%d%d?)-(%d%d?)%s+(%d%d?):(%d%d):(%d%d)" },
-    { "timestamp", "^(%d%d%d%d)-(%d%d?)-(%d%d?)%s+(%d%d?):(%d%d)" },
-    { "timestamp", "^(%d%d%d%d)-(%d%d?)-(%d%d?)%s+(%d%d?)" },
-    { "timestamp", "^(%d%d%d%d)-(%d%d?)-(%d%d?)" },
-    { "doc", "^%-%-%-[^%c]*" },
-    { ",", "^," },
-    { "string", "^%b{} *[^,%c]+", noinline = true },
-    { "{", "^{" },
-    { "}", "^}" },
-    { "string", "^%b[] *[^,%c]+", noinline = true },
-    { "[", "^%[" },
-    { "]", "^%]" },
-    { "-", "^%-", noinline = true },
-    { ":", "^:" },
-    { "pipe", "^(|)(%d*[+%-]?)", sep = "\n" },
-    { "pipe", "^(>)(%d*[+%-]?)", sep = " " },
-    { "id", "^([%w][%w %-_]*)(:[%s%c])" },
-    { "string", "^[^%c]+", noinline = true },
-    { "string", "^[^,%]}%c ]+" },
+local types = {
+  null = class:def('null'),
+  map = class:def('map'),
+  omap = class:def('omap'),
+  pairs = class:def('pairs'),
+  set = class:def('set'),
+  seq = class:def('seq'),
+  timestamp = class:def('timestamp'),
 }
-exports.tokenize = function(str)
-    local token
-    local row = 0
-    local ignore
-    local indents = 0
-    local lastIndents
-    local stack = {}
-    local indentAmount = 0
-    local inline = false
-    str = str:gsub("\r\n", "\010")
 
-    while #str > 0 do
-        for i in ipairs(tokens) do
-            local captures = {}
-            if not inline or tokens[i].noinline == nil then
-                captures = { str:match(tokens[i][2]) }
-            end
+local Null = types.null
+function Null.__tostring() return 'yaml.null' end
+function Null.isnull(v)
+  if v == nil then return true end
+  if type(v) == 'table' and getmetatable(v) == Null then return true end
+  return false
+end
+local null = Null()
 
-            if #captures > 0 then
-                captures.input = str:sub(0, 25)
-                token = table_clone(tokens[i])
-                token[2] = captures
-                local str2 = str:gsub(tokens[i][2], "", 1)
-                token.raw = str:sub(1, #str - #str2)
-                str = str2
+function types.timestamp:__init(y, m, d, h, i, s, f, z)
+  self.year = tonumber(y)
+  self.month = tonumber(m)
+  self.day = tonumber(d)
+  self.hour = tonumber(h or 0)
+  self.minute = tonumber(i or 0)
+  self.second = tonumber(s or 0)
+  if type(f) == 'string' and sfind(f, '^%d+$') then
+    self.fraction = tonumber(f) * math.pow(10, 3 - #f)
+  elseif f then
+    self.fraction = f
+  else
+    self.fraction = 0
+  end
+  self.timezone = z
+end
 
-                if token[1] == "{" or token[1] == "[" then
-                    inline = true
-                elseif token.const then
-                    str = token[2][2] .. str
-                    token.raw = token.raw:sub(1, #token.raw - #token[2][2])
-                elseif token[1] == "id" then
-                    str = token[2][2] .. str
-                    token.raw = token.raw:sub(1, #token.raw - #token[2][2])
-                    token[2][1] = string_trim(token[2][1])
-                elseif token[1] == "string" then
-                    local snip = token[2][1]
-                    if not token.force_text then
-                        if snip:match("^(-?%d+%.%d+)$") or snip:match("^(-?%d+)$") then
-                            token[1] = "number"
-                        end
-                    end
-                elseif token[1] == "comment" then
-                    ignore = true
-                elseif token[1] == "indent" then
-                    row = row + 1
-                    inline = false
-                    lastIndents = indents
-                    if indentAmount == 0 then
-                        indentAmount = #token[2][1]
-                    end
+function types.timestamp:__tostring()
+  return string.format(
+    '%04d-%02d-%02dT%02d:%02d:%02d.%03d%s',
+    self.year, self.month, self.day,
+    self.hour, self.minute, self.second, self.fraction,
+    self:gettz())
+end
 
-                    if indentAmount ~= 0 then
-                        indents = (#token[2][1] / indentAmount)
-                    else
-                        indents = 0
-                    end
+function types.timestamp:gettz()
+  if not self.timezone then
+    return ''
+  end
+  if self.timezone == 0 then
+    return 'Z'
+  end
+  local sign = self.timezone > 0
+  local z = sign and self.timezone or -self.timezone
+  local zh = math.floor(z)
+  local zi = (z - zh) * 60
+  return string.format(
+    '%s%02d:%02d', sign and '+' or '-', zh, zi)
+end
 
-                    if indents == lastIndents then
-                        ignore = true
-                    elseif indents > lastIndents + 2 then
-                        error(
-                            "SyntaxError: invalid indentation, got "
-                                .. tostring(indents)
-                                .. " instead of "
-                                .. tostring(lastIndents)
-                                .. context(token[2].input)
-                        )
-                    elseif indents > lastIndents + 1 then
-                        push(stack, token)
-                    elseif indents < lastIndents then
-                        local input = token[2].input
-                        token = { "dedent", { "", input = "" } }
-                        token.input = input
-                        while lastIndents > indents + 1 do
-                            lastIndents = lastIndents - 1
-                            push(stack, token)
-                        end
-                    end
-                end
-                token.row = row
-                break
-            end
-        end
 
-        if not ignore then
-            if token then
-                push(stack, token)
-                token = nil
-            else
-                error("SyntaxError " .. context(str))
-            end
-        end
+local function countindent(line)
+  local _, j = sfind(line, '^%s+')
+  if not j then
+    return 0, line
+  end
+  return j, ssub(line, j+1)
+end
 
-        ignore = false
+local Parser = {
+  timestamps=true,-- parse timestamps as objects instead of strings
+}
+
+function Parser:parsestring(line, stopper)
+  stopper = stopper or ''
+  local q = ssub(line, 1, 1)
+  if q == ' ' or q == '\t' then
+    return self:parsestring(ssub(line, 2))
+  end
+  if q == "'" then
+    local i = sfind(line, "'", 2, true)
+    if not i then
+      return nil, line
     end
-
-    return stack
-end
-
-Parser.peek = function(self, offset)
-    offset = offset or 1
-    return self.tokens[offset + self.current]
-end
-
-Parser.advance = function(self)
-    self.current = self.current + 1
-    return self.tokens[self.current]
-end
-
-Parser.advanceValue = function(self)
-    return self:advance()[2][1]
-end
-
-Parser.accept = function(self, type)
-    if self:peekType(type) then
-        return self:advance()
+    -- Unescape repeated single quotes.
+    while i < #line and ssub(line, i+1, i+1) == "'" do
+      i = sfind(line, "'", i + 2, true)
+      if not i then
+        return nil, line
+      end
     end
-end
-
-Parser.expect = function(self, type, msg)
-    return self:accept(type) or error(msg .. context(self:peek()[1].input))
-end
-
-Parser.expectDedent = function(self, msg)
-    return self:accept("dedent") or (self:peek() == nil) or error(msg .. context(self:peek()[2].input))
-end
-
-Parser.peekType = function(self, val, offset)
-    return self:peek(offset) and self:peek(offset)[1] == val
-end
-
-Parser.ignore = function(self, items)
-    local advanced
-    repeat
-        advanced = false
-        for _, v in pairs(items) do
-            if self:peekType(v) then
-                self:advance()
-                advanced = true
-            end
-        end
-    until advanced == false
-end
-
-Parser.ignoreSpace = function(self)
-    self:ignore({ "space" })
-end
-
-Parser.ignoreWhitespace = function(self)
-    self:ignore({ "space", "indent", "dedent" })
-end
-
-Parser.parse = function(self)
-    local ref = nil
-    if self:peekType("string") and not self:peek().force_text then
-        local char = self:peek()[2][1]:sub(1, 1)
-        if char == "&" then
-            ref = self:peek()[2][1]:sub(2)
-            self:advanceValue()
-            self:ignoreSpace()
-        elseif char == "*" then
-            ref = self:peek()[2][1]:sub(2)
-            return self.refs[ref]
-        end
-    end
-
-    local result
-    local c = {
-        indent = self:accept("indent") and 1 or 0,
-        token = self:peek(),
-    }
-    push(self.parse_stack, c)
-
-    if c.token[1] == "doc" then
-        result = self:parseDoc()
-    elseif c.token[1] == "-" then
-        result = self:parseList()
-    elseif c.token[1] == "{" then
-        result = self:parseInlineHash()
-    elseif c.token[1] == "[" then
-        result = self:parseInlineList()
-    elseif c.token[1] == "id" then
-        result = self:parseHash()
-    elseif c.token[1] == "string" then
-        result = self:parseString("\n")
-    elseif c.token[1] == "timestamp" then
-        result = self:parseTimestamp()
-    elseif c.token[1] == "number" then
-        result = tonumber(self:advanceValue())
-    elseif c.token[1] == "pipe" then
-        result = self:parsePipe()
-    elseif c.token.const == true then
-        self:advanceValue()
-        result = c.token.value
-    else
-        error("ParseError: unexpected token '" .. c.token[1] .. "'" .. context(c.token.input))
-    end
-
-    pop(self.parse_stack)
-    while c.indent > 0 do
-        c.indent = c.indent - 1
-        local term = "term " .. c.token[1] .. ": '" .. c.token[2][1] .. "'"
-        self:expectDedent("last " .. term .. " is not properly dedented")
-    end
-
-    if ref then
-        self.refs[ref] = result
-    end
-    return result
-end
-
-Parser.parseDoc = function(self)
-    self:accept("doc")
-    return self:parse()
-end
-
-Parser.inline = function(self)
-    local current = self:peek(0)
-    if not current then
-        return {}, 0
-    end
-
-    local inline = {}
-    local i = 0
-
-    while self:peek(i) and not self:peekType("indent", i) and current.row == self:peek(i).row do
-        inline[self:peek(i)[1]] = true
-        i = i - 1
-    end
-    return inline, -i
-end
-
-Parser.isInline = function(self)
-    local _, i = self:inline()
-    return i > 0
-end
-
-Parser.parent = function(self, level)
-    level = level or 1
-    return self.parse_stack[#self.parse_stack - level]
-end
-
-Parser.parentType = function(self, type, level)
-    return self:parent(level) and self:parent(level).token[1] == type
-end
-
-Parser.parseString = function(self)
-    if self:isInline() then
-        local result = self:advanceValue()
-
-        local types = self:inline()
-        if types["id"] and types["-"] then
-            if not self:peekType("indent") or not self:peekType("indent", 2) then
-                return result
-            end
-        end
-
-        if self:peekType("indent") then
-            self:expect("indent", "text block needs to start with indent")
-            local addtl = self:accept("indent")
-
-            result = result .. "\n" .. self:parseTextBlock("\n")
-
-            self:expectDedent("text block ending dedent missing")
-            if addtl then
-                self:expectDedent("text block ending dedent missing")
-            end
-        end
-        return result
-    else
-        return self:parseTextBlock("\n")
-    end
-end
-
-Parser.parsePipe = function(self)
-    local pipe = self:expect("pipe")
-    self:expect("indent", "text block needs to start with indent")
-    local result = self:parseTextBlock(pipe.sep)
-    self:expectDedent("text block ending dedent missing")
-    return result
-end
-
-Parser.parseTextBlock = function(self, sep)
-    local token = self:advance()
-    local result = string_trim(token.raw, "\n")
-    local indents = 0
-    while self:peek() ~= nil and (indents > 0 or not self:peekType("dedent")) do
-        local newtoken = self:advance()
-        while token.row < newtoken.row do
-            result = result .. sep
-            token.row = token.row + 1
-        end
-        if newtoken[1] == "indent" then
-            indents = indents + 1
-        elseif newtoken[1] == "dedent" then
-            indents = indents - 1
+    return ssub(line, 2, i-1):gsub("''", "'"), ssub(line, i+1)
+  end
+  if q == '"' then
+    local i, buf = 2, ''
+    while i < #line do
+      local c = ssub(line, i, i)
+      if c == '\\' then
+        local n = ssub(line, i+1, i+1)
+        if UNESCAPES[n] ~= nil then
+          buf = buf..UNESCAPES[n]
+        elseif n == 'x' then
+          local h = ssub(i+2,i+3)
+          if sfind(h, '^[0-9a-fA-F]$') then
+            buf = buf..schar(tonumber(h, 16))
+            i = i + 2
+          else
+            buf = buf..'x'
+          end
         else
-            result = result .. string_trim(newtoken.raw, "\n")
+          buf = buf..n
         end
+        i = i + 1
+      elseif c == q then
+        break
+      else
+        buf = buf..c
+      end
+      i = i + 1
     end
-    return result
+    return buf, ssub(line, i+1)
+  end
+  if q == '{' or q == '[' then  -- flow style
+    return nil, line
+  end
+  if q == '|' or q == '>' then  -- block
+    return nil, line
+  end
+  if q == '-' or q == ':' then
+    if ssub(line, 2, 2) == ' ' or ssub(line, 2, 2) == '\n' or #line == 1 then
+      return nil, line
+    end
+  end
+
+  if line == "*" then
+    error("did not find expected alphabetic or numeric character")
+  end
+
+  local buf = ''
+  while #line > 0 do
+    local c = ssub(line, 1, 1)
+    if sfind(stopper, c, 1, true) then
+      break
+    elseif c == ':' and (ssub(line, 2, 2) == ' ' or ssub(line, 2, 2) == '\n' or #line == 1) then
+      break
+    elseif c == '#' and (ssub(buf, #buf, #buf) == ' ') then
+      break
+    else
+      buf = buf..c
+    end
+    line = ssub(line, 2)
+  end
+  buf = rtrim(buf)
+  local val = tonumber(buf) or buf
+  return val, line
 end
 
-Parser.parseHash = function(self, hash)
-    hash = hash or {}
-    local indents = 0
+local function isemptyline(line)
+  return line == '' or sfind(line, '^%s*$') or sfind(line, '^%s*#')
+end
 
-    if self:isInline() then
-        local id = self:advanceValue()
-        self:expect(":", "expected semi-colon after id")
-        self:ignoreSpace()
-        if self:accept("indent") then
-            indents = indents + 1
-            hash[id] = self:parse()
+local function equalsline(line, needle)
+  return startswith(line, needle) and isemptyline(ssub(line, #needle+1))
+end
+
+local function compactifyemptylines(lines)
+  -- Appends empty lines as "\n" to the end of the nearest preceding non-empty line
+  local compactified = {}
+  local lastline = {}
+  for i = 1, #lines do
+    local line = lines[i]
+    if isemptyline(line) then
+      if #compactified > 0 and i < #lines then
+        tinsert(lastline, "\n")
+      end
+    else
+      if #lastline > 0 then
+        tinsert(compactified, tconcat(lastline, ""))
+      end
+      lastline = {line}
+    end
+  end
+  if #lastline > 0 then
+    tinsert(compactified, tconcat(lastline, ""))
+  end
+  return compactified
+end
+
+local function checkdupekey(map, key)
+  if rawget(map, key) ~= nil then
+    -- print("found a duplicate key '"..key.."' in line: "..line)
+    local suffix = 1
+    while rawget(map, key..'_'..suffix) do
+      suffix = suffix + 1
+    end
+    key = key ..'_'..suffix
+  end
+  return key
+end
+
+
+function Parser:parseflowstyle(line, lines)
+  local stack = {}
+  while true do
+    if #line == 0 then
+      if #lines == 0 then
+        break
+      else
+        line = tremove(lines, 1)
+      end
+    end
+    local c = ssub(line, 1, 1)
+    if c == '#' then
+      line = ''
+    elseif c == ' ' or c == '\t' or c == '\r' or c == '\n' then
+      line = ssub(line, 2)
+    elseif c == '{' or c == '[' then
+      tinsert(stack, {v={},t=c})
+      line = ssub(line, 2)
+    elseif c == ':' then
+      local s = tremove(stack)
+      tinsert(stack, {v=s.v, t=':'})
+      line = ssub(line, 2)
+    elseif c == ',' then
+      local value = tremove(stack)
+      if value.t == ':' or value.t == '{' or value.t == '[' then error() end
+      if stack[#stack].t == ':' then
+        -- map
+        local key = tremove(stack)
+        key.v = checkdupekey(stack[#stack].v, key.v)
+        stack[#stack].v[key.v] = value.v
+      elseif stack[#stack].t == '{' then
+        -- set
+        stack[#stack].v[value.v] = true
+      elseif stack[#stack].t == '[' then
+        -- seq
+        tinsert(stack[#stack].v, value.v)
+      end
+      line = ssub(line, 2)
+    elseif c == '}' then
+      if stack[#stack].t == '{' then
+        if #stack == 1 then break end
+        stack[#stack].t = '}'
+        line = ssub(line, 2)
+      else
+        line = ','..line
+      end
+    elseif c == ']' then
+      if stack[#stack].t == '[' then
+        if #stack == 1 then break end
+        stack[#stack].t = ']'
+        line = ssub(line, 2)
+      else
+        line = ','..line
+      end
+    else
+      local s, rest = self:parsestring(line, ',{}[]')
+      if not s then
+        error('invalid flowstyle line: '..line)
+      end
+      tinsert(stack, {v=s, t='s'})
+      line = rest
+    end
+  end
+  return stack[1].v, line
+end
+
+function Parser:parseblockstylestring(line, lines, indent)
+  if #lines == 0 then
+    error("failed to find multi-line scalar content")
+  end
+  local s = {}
+  local firstindent = -1
+  local endline = -1
+  for i = 1, #lines do
+    local ln = lines[i]
+    local idt = countindent(ln)
+    if idt <= indent then
+      break
+    end
+    if ln == '' then
+      tinsert(s, '')
+    else
+      if firstindent == -1 then
+        firstindent = idt
+      elseif idt < firstindent then
+        break
+      end
+      tinsert(s, ssub(ln, firstindent + 1))
+    end
+    endline = i
+  end
+
+  local striptrailing = true
+  local sep = '\n'
+  local newlineatend = true
+  if line == '|' then
+    striptrailing = true
+    sep = '\n'
+    newlineatend = true
+  elseif line == '|+' then
+    striptrailing = false
+    sep = '\n'
+    newlineatend = true
+  elseif line == '|-' then
+    striptrailing = true
+    sep = '\n'
+    newlineatend = false
+  elseif line == '>' then
+    striptrailing = true
+    sep = ' '
+    newlineatend = true
+  elseif line == '>+' then
+    striptrailing = false
+    sep = ' '
+    newlineatend = true
+  elseif line == '>-' then
+    striptrailing = true
+    sep = ' '
+    newlineatend = false
+  else
+    error('invalid blockstyle string:'..line)
+  end
+
+  if #s == 0 then
+    return ""
+  end
+
+  local _, eonl = s[#s]:gsub('\n', '\n')
+  s[#s] = rtrim(s[#s])
+  if striptrailing then
+    eonl = 0
+  end
+  if newlineatend then
+    eonl = eonl + 1
+  end
+  for i = endline, 1, -1 do
+    tremove(lines, i)
+  end
+  return tconcat(s, sep)..string.rep('\n', eonl)
+end
+
+function Parser:parsetimestamp(line)
+  local _, p1, y, m, d = sfind(line, '^(%d%d%d%d)%-(%d%d)%-(%d%d)')
+  if not p1 then
+    return nil, line
+  end
+  if p1 == #line then
+    return types.timestamp(y, m, d), ''
+  end
+  local _, p2, h, i, s = sfind(line, '^[Tt ](%d+):(%d+):(%d+)', p1+1)
+  if not p2 then
+    return types.timestamp(y, m, d), ssub(line, p1+1)
+  end
+  if p2 == #line then
+    return types.timestamp(y, m, d, h, i, s), ''
+  end
+  local _, p3, f = sfind(line, '^%.(%d+)', p2+1)
+  if not p3 then
+    p3 = p2
+    f = 0
+  end
+  local zc = ssub(line, p3+1, p3+1)
+  local _, p4, zs, z = sfind(line, '^ ?([%+%-])(%d+)', p3+1)
+  if p4 then
+    z = tonumber(z)
+    local _, p5, zi = sfind(line, '^:(%d+)', p4+1)
+    if p5 then
+      z = z + tonumber(zi) / 60
+    end
+    z = zs == '-' and -tonumber(z) or tonumber(z)
+  elseif zc == 'Z' then
+    p4 = p3 + 1
+    z = 0
+  else
+    p4 = p3
+    z = false
+  end
+  return types.timestamp(y, m, d, h, i, s, f, z), ssub(line, p4+1)
+end
+
+function Parser:parsescalar(line, lines, indent)
+  line = trim(line)
+  line = gsub(line, '^%s*#.*$', '')  -- comment only -> ''
+  line = gsub(line, '^%s*', '')  -- trim head spaces
+
+  if line == '' or line == '~' then
+    return null
+  end
+
+  if self.timestamps then
+    local ts, _ = self:parsetimestamp(line)
+    if ts then
+      return ts
+    end
+  end
+
+  local s, _ = self:parsestring(line)
+  -- startswith quote ... string
+  -- not startswith quote ... maybe string
+  if s and (startswith(line, '"') or startswith(line, "'")) then
+    return s
+  end
+
+  if startswith('!', line) then  -- unexpected tagchar
+    error('unsupported line: '..line)
+  end
+
+  if equalsline(line, '{}') then
+    return {}
+  end
+  if equalsline(line, '[]') then
+    return {}
+  end
+
+  if startswith(line, '{') or startswith(line, '[') then
+    return self:parseflowstyle(line, lines)
+  end
+
+  if startswith(line, '|') or startswith(line, '>') then
+    return self:parseblockstylestring(line, lines, indent)
+  end
+
+  -- Regular unquoted string
+  line = gsub(line, '%s*#.*$', '')  -- trim tail comment
+  local v = line
+  if v == 'null' or v == 'Null' or v == 'NULL'then
+    return null
+  elseif v == 'true' or v == 'True' or v == 'TRUE' then
+    return true
+  elseif v == 'false' or v == 'False' or v == 'FALSE' then
+    return false
+  elseif v == '.inf' or v == '.Inf' or v == '.INF' then
+    return math.huge
+  elseif v == '+.inf' or v == '+.Inf' or v == '+.INF' then
+    return math.huge
+  elseif v == '-.inf' or v == '-.Inf' or v == '-.INF' then
+    return -math.huge
+  elseif v == '.nan' or v == '.NaN' or v == '.NAN' then
+    return 0 / 0
+  elseif sfind(v, '^[%+%-]?[0-9]+$') or sfind(v, '^[%+%-]?[0-9]+%.$')then
+    return tonumber(v)  -- : int
+  elseif sfind(v, '^[%+%-]?[0-9]+%.[0-9]+$') then
+    return tonumber(v)
+  end
+  return s or v
+end
+
+function Parser:parseseq(line, lines, indent)
+  local seq = setmetatable({}, types.seq)
+  if line ~= '' then
+    error()
+  end
+  while #lines > 0 do
+    -- Check for a new document
+    line = lines[1]
+    if startswith(line, '---') then
+      while #lines > 0 and not startswith(lines, '---') do
+        tremove(lines, 1)
+      end
+      return seq
+    end
+
+    -- Check the indent level
+    local level = countindent(line)
+    if level < indent then
+      return seq
+    elseif level > indent then
+      error("found bad indenting in line: ".. line)
+    end
+
+    local i, j = sfind(line, '%-%s+')
+    if not i then
+      i, j = sfind(line, '%-$')
+      if not i then
+        return seq
+      end
+    end
+    local rest = ssub(line, j+1)
+
+    if sfind(rest, '^[^\'\"%s]*:%s*$') or sfind(rest, '^[^\'\"%s]*:%s+.') then
+      -- Inline nested hash
+      -- There are two patterns need to match as inline nested hash
+      --   first one should have no other characters except whitespace after `:`
+      --   and the second one should have characters besides whitespace after `:`
+      --
+      --  value:
+      --    - foo:
+      --        bar: 1
+      --
+      -- and
+      --
+      --  value:
+      --    - foo: bar
+      --
+      -- And there is one pattern should not be matched, where there is no space after `:`
+      --   in below, `foo:bar` should be parsed into a single string
+      --
+      -- value:
+      --   - foo:bar
+      local indent2 = j
+      lines[1] = string.rep(' ', indent2)..rest
+      tinsert(seq, self:parsemap('', lines, indent2))
+    elseif sfind(rest, '^%-%s+') then
+      -- Inline nested seq
+      local indent2 = j
+      lines[1] = string.rep(' ', indent2)..rest
+      tinsert(seq, self:parseseq('', lines, indent2))
+    elseif isemptyline(rest) then
+      tremove(lines, 1)
+      if #lines == 0 then
+        tinsert(seq, null)
+        return seq
+      end
+      if sfind(lines[1], '^%s*%-') then
+        local nextline = lines[1]
+        local indent2 = countindent(nextline)
+        if indent2 == indent then
+          -- Null seqay entry
+          tinsert(seq, null)
         else
-            hash[id] = self:parse()
-            if self:accept("indent") then
-                indents = indents + 1
-            end
+          tinsert(seq, self:parseseq('', lines, indent2))
         end
-        self:ignoreSpace()
+      else
+        -- - # comment
+        --   key: value
+        local nextline = lines[1]
+        local indent2 = countindent(nextline)
+        tinsert(seq, self:parsemap('', lines, indent2))
+      end
+    elseif line == "*" then
+      error("did not find expected alphabetic or numeric character")
+    elseif rest then
+      -- Array entry with a value
+      local nextline = lines[1]
+      local indent2 = countindent(nextline)
+      tremove(lines, 1)
+      tinsert(seq, self:parsescalar(rest, lines, indent2))
     end
-
-    while self:peekType("id") do
-        local id = self:advanceValue()
-        self:expect(":", "expected semi-colon after id")
-        self:ignoreSpace()
-        hash[id] = self:parse()
-        self:ignoreSpace()
-    end
-
-    while indents > 0 do
-        self:expectDedent("expected dedent")
-        indents = indents - 1
-    end
-
-    return hash
+  end
+  return seq
 end
 
-Parser.parseInlineHash = function(self)
-    local id
-    local hash = {}
-    local i = 0
+function Parser:parseset(line, lines, indent)
+  if not isemptyline(line) then
+    error('not seq line: '..line)
+  end
+  local set = setmetatable({}, types.set)
+  while #lines > 0 do
+    -- Check for a new document
+    line = lines[1]
+    if startswith(line, '---') then
+      while #lines > 0 and not startswith(lines, '---') do
+        tremove(lines, 1)
+      end
+      return set
+    end
 
-    self:accept("{")
-    while not self:accept("}") do
-        self:ignoreSpace()
-        if i > 0 then
-            self:expect(",", "expected comma")
+    -- Check the indent level
+    local level = countindent(line)
+    if level < indent then
+      return set
+    elseif level > indent then
+      error("found bad indenting in line: ".. line)
+    end
+
+    local i, j = sfind(line, '%?%s+')
+    if not i then
+      i, j = sfind(line, '%?$')
+      if not i then
+        return set
+      end
+    end
+    local rest = ssub(line, j+1)
+
+    if sfind(rest, '^[^\'\"%s]*:') then
+      -- Inline nested hash
+      local indent2 = j
+      lines[1] = string.rep(' ', indent2)..rest
+      set[self:parsemap('', lines, indent2)] = true
+    elseif sfind(rest, '^%s+$') then
+      tremove(lines, 1)
+      if #lines == 0 then
+        tinsert(set, null)
+        return set
+      end
+      if sfind(lines[1], '^%s*%?') then
+        local indent2 = countindent(lines[1])
+        if indent2 == indent then
+          -- Null array entry
+          set[null] = true
+        else
+          set[self:parseseq('', lines, indent2)] = true
         end
+      end
 
-        self:ignoreWhitespace()
-        if self:peekType("id") then
-            id = self:advanceValue()
-            if id then
-                self:expect(":", "expected semi-colon after id")
-                self:ignoreSpace()
-                hash[id] = self:parse()
-                self:ignoreWhitespace()
-            end
+    elseif rest then
+      tremove(lines, 1)
+      set[self:parsescalar(rest, lines)] = true
+    else
+      error("failed to classify line: "..line)
+    end
+  end
+  return set
+end
+
+function Parser:parsemap(line, lines, indent)
+  if not isemptyline(line) then
+    error('not map line: '..line)
+  end
+  local map = setmetatable({}, types.map)
+  while #lines > 0 do
+    -- Check for a new document
+    line = lines[1]
+    if line == end_symbol or line == end_break_symbol then
+      for i, _ in ipairs(lines) do
+        lines[i] = nil
+      end
+      return map
+    end
+
+    if startswith(line, '---') then
+      while #lines > 0 and not startswith(lines, '---') do
+        tremove(lines, 1)
+      end
+      return map
+    end
+
+    -- Check the indent level
+    local level, _ = countindent(line)
+    if level < indent then
+      return map
+    elseif level > indent then
+      error("found bad indenting in line: ".. line)
+    end
+
+    -- Find the key
+    local key
+    local s, rest = self:parsestring(line)
+
+    -- Quoted keys
+    if s and startswith(rest, ':') then
+      local sc = self:parsescalar(s, {}, 0)
+      if sc and type(sc) ~= 'string' then
+        key = sc
+      else
+        key = s
+      end
+      line = ssub(rest, 2)
+    else
+      error("failed to classify line: "..line)
+    end
+
+    key = checkdupekey(map, key)
+    line = ltrim(line)
+
+    if ssub(line, 1, 1) == '!' then
+      -- ignore type
+      local rh = ltrim(ssub(line, 3))
+      local typename = smatch(rh, '^!?[^%s]+')
+      line = ltrim(ssub(rh, #typename+1))
+    end
+
+    if not isemptyline(line) then
+      tremove(lines, 1)
+      line = ltrim(line)
+      map[key] = self:parsescalar(line, lines, indent)
+    else
+      -- An indent
+      tremove(lines, 1)
+      if #lines == 0 then
+        map[key] = null
+        return map;
+      end
+      if sfind(lines[1], '^%s*%-') then
+        local indent2 = countindent(lines[1])
+        map[key] = self:parseseq('', lines, indent2)
+      elseif sfind(lines[1], '^%s*%?') then
+        local indent2 = countindent(lines[1])
+        map[key] = self:parseset('', lines, indent2)
+      else
+        local indent2 = countindent(lines[1])
+        if indent >= indent2 then
+          -- Null hash entry
+          map[key] = null
+        else
+          map[key] = self:parsemap('', lines, indent2)
         end
-
-        i = i + 1
+      end
     end
-    return hash
+  end
+  return map
 end
 
-Parser.parseList = function(self)
-    local list = {}
-    while self:accept("-") do
-        self:ignoreSpace()
-        list[#list + 1] = self:parse()
 
-        self:ignoreSpace()
+-- : (list<str>)->dict
+function Parser:parsedocuments(lines)
+  lines = compactifyemptylines(lines)
+
+  if sfind(lines[1], '^%%YAML') then tremove(lines, 1) end
+
+  local root = {}
+  local in_document = false
+  while #lines > 0 do
+    local line = lines[1]
+    -- Do we have a document header?
+    local docright;
+    if sfind(line, '^%-%-%-') then
+      -- Handle scalar documents
+      docright = ssub(line, 4)
+      tremove(lines, 1)
+      in_document = true
     end
-    return list
-end
+    if docright then
+      if (not sfind(docright, '^%s+$') and
+          not sfind(docright, '^%s+#')) then
+        tinsert(root, self:parsescalar(docright, lines))
+      end
+    elseif #lines == 0 or startswith(line, '---') then
+      -- A naked document
+      tinsert(root, null)
+      while #lines > 0 and not sfind(lines[1], '---') do
+        tremove(lines, 1)
+      end
+      in_document = false
+    -- XXX The final '-+$' is to look for -- which ends up being an
+    -- error later.
+    elseif not in_document and #root > 0 then
+      -- only the first document can be explicit
+      error('parse error: '..line)
+    elseif sfind(line, '^%s*%-') then
+      -- An array at the root
+      tinsert(root, self:parseseq('', lines, 0))
+    elseif sfind(line, '^%s*[^%s]') then
+      -- A hash at the root
+      local level = countindent(line)
+      tinsert(root, self:parsemap('', lines, level))
+    else
+      -- Shouldn't get here.  @lines have whitespace-only lines
+      -- stripped, and previous match is a line with any
+      -- non-whitespace.  So this clause should only be reachable via
+      -- a perlbug where \s is not symmetric with \S
 
-Parser.parseInlineList = function(self)
-    local list = {}
-    local i = 0
-    self:accept("[")
-    while not self:accept("]") do
-        self:ignoreSpace()
-        if i > 0 then
-            self:expect(",", "expected comma")
-        end
-
-        self:ignoreSpace()
-        list[#list + 1] = self:parse()
-        self:ignoreSpace()
-        i = i + 1
+      -- uncoverable statement
+      error('parse error: '..line)
     end
-
-    return list
+  end
+  if #root > 1 and Null.isnull(root[1]) then
+    tremove(root, 1)
+    return root
+  end
+  return root
 end
 
-Parser.parseTimestamp = function(self)
-    local capture = self:advance()[2]
+--- Parse yaml string into table.
+function Parser:parse(source)
+  local lines = {}
+  for line in string.gmatch(source .. '\n', '(.-)\r?\n') do
+    tinsert(lines, line)
+  end
 
-    return os.time({
-        year = capture[1],
-        month = capture[2],
-        day = capture[3],
-        hour = capture[4] or 0,
-        min = capture[5] or 0,
-        sec = capture[6] or 0,
-        isdst = false,
-    }) - os.time({ year = 1970, month = 1, day = 1, hour = 8 })
+  local docs = self:parsedocuments(lines)
+  if #docs == 1 then
+    return docs[1]
+  end
+
+  return docs
 end
 
-exports.eval = function(str)
-    return Parser:new(exports.tokenize(str)):parse()
+local function parse(source, options)
+  local options = options or {}
+  local parser = setmetatable (options, {__index=Parser})
+  return parser:parse(source)
 end
 
-exports.dump = table_print
-
-return exports
+return {
+  version = 0.1,
+  parse = parse,
+}

--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,6 @@ run = "lua tests/run_tests.lua"
 description = "Run integration tests against the linked backend plugin"
 run = [
     "mise plugin link --force krew .",
-    "mise cache clear",
     "bash tests/integration_test.sh",
 ]
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -30,8 +30,17 @@ check() {
 
 echo "mise-krew integration tests"
 
-mise uninstall krew:tree --all >/dev/null 2>&1 || true
-mise uninstall krew:browse-pvc --all >/dev/null 2>&1 || true
+# Per-tool cleanup: removes installed binaries and the plugin's per-tool
+# version index. Never touches `registry/` (the shared krew-index clone) so
+# repeated local runs don't pay a full re-clone.
+clean_tool() {
+    local tool="$1"
+    mise uninstall "krew:$tool" --all >/dev/null 2>&1 || true
+    rm -f "cache/$tool.json"
+}
+
+clean_tool tree
+clean_tool browse-pvc
 
 check "plugin is linked"                          "mise plugin list | grep -q krew"
 check "list remote versions for tree"             "mise ls-remote krew:tree | grep -q 'v0.4'"

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -56,6 +56,14 @@ BPVC_INSTALL=$(mise where krew:browse-pvc@latest)
 check "hyphenated plugin renamed to underscores"  "test -f '${BPVC_INSTALL}/kubectl-browse_pvc'"
 check "original hyphen-named binary removed"      "test ! -f '${BPVC_INSTALL}/kubectl-browse-pvc'"
 
+# Regression coverage:
+#   #6: oidc-login, get-all, deprecations, df-pv, access-matrix, cilium-policy-gen
+#   #7: rook-ceph
+for t in oidc-login get-all deprecations df-pv access-matrix cilium-policy-gen rook-ceph; do
+    clean_tool "$t"
+    check "install krew:$t@latest" "mise install krew:$t@latest"
+done
+
 if [ $FAILED -eq 0 ]; then
     printf "%s%d passed%s\n" "$GREEN" "$PASSED" "$NC"
     exit 0

--- a/tests/test_installer.lua
+++ b/tests/test_installer.lua
@@ -9,16 +9,4 @@ M.test("target_bin_name: hyphens become underscores", function()
     M.assert_equals(installer.target_bin_name("foo-bar-baz"), "kubectl-foo_bar_baz")
 end)
 
-M.test("target_bin_name: rename_exe overrides", function()
-    M.assert_equals(installer.target_bin_name("browse-pvc", { rename_exe = "kubectl-custom" }), "kubectl-custom")
-end)
-
-M.test("target_bin_name: empty rename_exe falls back", function()
-    M.assert_equals(installer.target_bin_name("browse-pvc", { rename_exe = "" }), "kubectl-browse_pvc")
-end)
-
-M.test("target_bin_name: nil opts", function()
-    M.assert_equals(installer.target_bin_name("browse-pvc", nil), "kubectl-browse_pvc")
-end)
-
 return M


### PR DESCRIPTION
fix: handle manifests broken by description-block YAML quirks and over-eager error guards
Three bugs caused install/list to fail for plugins like oidc-login,
get-all, rook-ceph, and cilium-policy-gen:

- The vendored lua-yaml parser dropped keys after `description: |` blocks
  containing blank lines or unusual indent, so `spec.platforms` parsed as
  empty. Swap to lua-tinyyaml (zepinglee fork), which handles these cases.
- `git log --follow` surfaced pre-`plugins/`-reorganization commits whose
  paths broke `git show`. Drop --follow. (diagnosis and fix from @qjoly in https://github.com/soupglasses/mise-krew/issues/7)
- `get_manifest_at_commit` rejected manifests whose content contained the
  literal substrings "error" or "fatal" (e.g. cilium-policy-gen's
  description mentions "error-prone"). Replace the over-eager string match
  with a pcall guard around cmd.exec.

Adds integration coverage for all 7 affected plugins.

Closes https://github.com/soupglasses/mise-krew/issues/6
Closes https://github.com/soupglasses/mise-krew/issues/7